### PR TITLE
Update main.vue

### DIFF
--- a/packages/tree-transfer/src/main.vue
+++ b/packages/tree-transfer/src/main.vue
@@ -161,7 +161,7 @@ export default {
                         const result = filterData(item[this.props.children])
                         if (result.length > 0) {
                             item[this.props.children] = result
-                            const find = res.find(i => i.key === item.key)
+                            const find = res.find(i => i[this.props.key] === item[this.props.key])
 
                             if (find === undefined) {
                                 res.push(item)


### PR DESCRIPTION
fix：当树的数据结构不是key而是传入的{key:id},右侧树结构过滤不完整